### PR TITLE
[WIP] Uc 3 02

### DIFF
--- a/src/main/java/eu/seal/idp/config/SAMLWithRelayStateEntryPoint.java
+++ b/src/main/java/eu/seal/idp/config/SAMLWithRelayStateEntryPoint.java
@@ -21,7 +21,9 @@ public class SAMLWithRelayStateEntryPoint extends SAMLEntryPoint {
         }
         HttpServletRequestAdapter httpServletRequestAdapter = (HttpServletRequestAdapter) context.getInboundMessageTransport();
         String session = httpServletRequestAdapter.getParameterValue("session");
-        ssoProfileOptions.setRelayState("/as/callback?session=" + session);
+        String callback = httpServletRequestAdapter.getParameterValue("callback"); 
+        System.out.println("Received session = " + session + "Received callback" + callback);
+        ssoProfileOptions.setRelayState(callback + "?session=" + session);
         
         return ssoProfileOptions;
     }

--- a/src/main/java/eu/seal/idp/controllers/AuthenticateController.java
+++ b/src/main/java/eu/seal/idp/controllers/AuthenticateController.java
@@ -82,7 +82,6 @@ public class AuthenticateController {
 		ObjectMapper mapper = new ObjectMapper();
 		String rspValidate = netServ.sendGet(sessionMngrUrl, "/sm/validateToken", requestParams, 1);
 		SessionMngrResponse resp = mapper.readValue(rspValidate, SessionMngrResponse.class);
-
 		if (resp.getCode().toString().equals("OK") && StringUtils.isEmpty(resp.getError())) {
 			String sealSessionId = resp.getSessionData().getSessionId();
 			requestParams.clear();
@@ -92,7 +91,7 @@ public class AuthenticateController {
 				LOG.error("no idpRequest found in session" + sealSessionId);
 				return "redirect:/authfail";
 			} else {
-				return "redirect:/saml/login?session=" + sealSessionId + "?callback=/as/callback";
+				return "redirect:/saml/login?session=" + sealSessionId + "&callback=/as/callback";
 			}
 		} else {
 			LOG.error("Something wrong with the SM session: " + resp.getError());

--- a/src/main/java/eu/seal/idp/controllers/CallbackController.java
+++ b/src/main/java/eu/seal/idp/controllers/CallbackController.java
@@ -93,8 +93,6 @@ public class CallbackController {
 		List <DataSet> dsArrayList = new ArrayList();
 		DataStore datastore = new DataStore();
 		ObjectMapper mapper = new ObjectMapper();
-		LOG.info("Recovered datastore \n" + datastore.toString());
-		
 		if(!StringUtils.isEmpty(dataStoreString)) {
 			
 			datastore = mapper.readValue(dataStoreString, DataStore.class);
@@ -108,22 +106,21 @@ public class CallbackController {
 		DataSet receivedDataset = (new SAMLDatasetDetailsServiceImpl()).loadDatasetBySAML(recoveredSessionID, credentials);
 		dsArrayList.add(receivedDataset);
 		datastore.setClearData(dsArrayList);
-		LOG.info("new Datastore \n" + datastore.toString());
 		
 		// Update Session Manager 
 		String stringifiedDatastore = mapper.writeValueAsString(datastore);
 		UpdateDataRequest updateReq = new UpdateDataRequest(sessionId, "dataStore", stringifiedDatastore);
-		
+				
+				
 		// Stores in the DataStore 
-		String rsp = netServ.sendPostBody(sessionMngrUrl, "/sm/updateSessionData", updateReq, "application/json", 1);
-		LOG.info("Response" + rsp);
+		netServ.sendPostBody(sessionMngrUrl, "/sm/updateSessionData", updateReq, "application/json", 1);
 		
 		// Redirect to Callback Address
 		return "redirect:" + callBackAddr; 
 	}
 	
 	/**
-	 * Manages SAML success callback (mapped from /saml/SSO callback) and writes to the DataStore
+	 * Manages SAML IS success callback (mapped from /saml/SSO callback) and writes to the DataStore
 	 * @param session 
 	 * @param authentication
 	 * @param model
@@ -131,7 +128,6 @@ public class CallbackController {
 	 * @return 
 	 * @throws IOException
 	 * @throws NoSuchAlgorithmException
-	 * @throws KeyStoreException
 	 */
 	
 	@RequestMapping("/is/callback")
@@ -153,37 +149,20 @@ public class CallbackController {
 		String callBackAddr = (String) smResp.getSessionData().getSessionVariables().get("clientCallbackAddr");
 
 
-//		// Recover DataStore
-//		String dataStoreString = (String) smResp.getSessionData().getSessionVariables().get("dataStore");
-//		List <DataSet> dsArrayList = new ArrayList();
-//		DataStore datastore = new DataStore();
-//		ObjectMapper mapper = new ObjectMapper();
-//		LOG.info("Recovered datastore \n" + datastore.toString());
-//		
-//		if(!StringUtils.isEmpty(dataStoreString)) {
-//			
-//			datastore = mapper.readValue(dataStoreString, DataStore.class);
-//			dsArrayList = datastore.getClearData();
-//		} else { 
-//			String datastoreId = UUID.randomUUID().toString();
-//			datastore.setId(datastoreId);
-//		}
-//		
-//		// Update DataStore with incoming DataSet
-//		DataSet receivedDataset = (new SAMLDatasetDetailsServiceImpl()).loadDatasetBySAML(recoveredSessionID, credentials);
-//		dsArrayList.add(receivedDataset);
-//		datastore.setClearData(dsArrayList);
-//		LOG.info("new Datastore \n" + datastore.toString());
-//		
-//		// Update Session Manager 
-//		String stringifiedDatastore = mapper.writeValueAsString(datastore);
-//		UpdateDataRequest updateReq = new UpdateDataRequest(sessionId, "dataStore", stringifiedDatastore);
-//		
-//		// Stores in the DataStore 
-//		String rsp = netServ.sendPostBody(sessionMngrUrl, "/sm/updateSessionData", updateReq, "application/json", 1);
-//		LOG.info("Response" + rsp);
+		List <DataSet> dsArrayList = new ArrayList();
+		DataStore datastore = new DataStore();
 		
-		// Redirect to Callback Address
+		DataSet receivedDataset = (new SAMLDatasetDetailsServiceImpl()).loadDatasetBySAML(recoveredSessionID, credentials);	
+		dsArrayList.add(receivedDataset);
+		
+		// Update Session Manager 
+		ObjectMapper mapper = new ObjectMapper();
+		String stringifiedDatastore = mapper.writeValueAsString(datastore);
+		UpdateDataRequest updateReq = new UpdateDataRequest(sessionId, "dsResponse", stringifiedDatastore);
+				
+		
+		netServ.sendPostBody(sessionMngrUrl, "/sm/updateSessionData", updateReq, "application/json", 1);
+		
 		return "redirect:" + callBackAddr; 
 	}
 

--- a/src/main/java/eu/seal/idp/controllers/ISController.java
+++ b/src/main/java/eu/seal/idp/controllers/ISController.java
@@ -92,10 +92,10 @@ public class ISController {
 				LOG.error("no idpRequest found in session" + sealSessionId);
 				return "redirect:/authfail";
 			} else {
-				return "redirect:/saml/login?session=" + sealSessionId + "?callback=/is/callback";
+				return "redirect:/saml/login?session=" + sealSessionId + "&callback=/is/callback";
 			}
 		} else {
-			LOG.error("Something wrong with the SM session: " + resp.getError());
+			LOG.error(resp.getError());
 			redirectAttrs.addFlashAttribute("errorMsg", "Error validating token! " + resp.getError());
 		}
 

--- a/src/main/java/eu/seal/idp/controllers/ISController.java
+++ b/src/main/java/eu/seal/idp/controllers/ISController.java
@@ -61,7 +61,7 @@ public class ISController {
 	}
 
 	/**
-	 * Redirects an existing IDP request to the IDP 
+	 * Redirects an existing AP request to the IDP 
 	 * @param msToken
 	 * @param model
 	 * @param redirectAttrs
@@ -92,7 +92,7 @@ public class ISController {
 				LOG.error("no idpRequest found in session" + sealSessionId);
 				return "redirect:/authfail";
 			} else {
-				return "redirect:/saml/login?session=" + sealSessionId + "?callback=/is/callback";
+				return "redirect:/saml/login?session=" + sealSessionId + "&callback=/is/callback";
 			}
 		} else {
 			LOG.error("Something wrong with the SM session: " + resp.getError());

--- a/src/main/java/eu/seal/idp/controllers/ISController.java
+++ b/src/main/java/eu/seal/idp/controllers/ISController.java
@@ -43,7 +43,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
  *  */
 
 @Controller
-public class AuthenticateController {
+public class ISController {
 
 	private final static Logger LOG = LoggerFactory.getLogger(AuthenticateController.class);
 
@@ -51,7 +51,7 @@ public class AuthenticateController {
 	private final KeyStoreService keyServ;
 
 	@Autowired
-	public AuthenticateController(KeyStoreService keyServ,
+	public ISController(KeyStoreService keyServ,
 			SealMetadataService metadataServ) throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException, UnsupportedEncodingException, InvalidKeySpecException, IOException {
 		this.keyServ = keyServ;
 		Key signingKey = this.keyServ.getSigningKey();
@@ -73,8 +73,8 @@ public class AuthenticateController {
 	 * @throws JsonParseException 
 	 */
 
-	@RequestMapping(value = {"/as/authenticate"}, method = {RequestMethod.POST, RequestMethod.GET})
-	public String authenticate(@RequestParam(value = "msToken", required = true) String msToken, RedirectAttributes redirectAttrs, HttpServletRequest request) throws KeyStoreException, JsonParseException, JsonMappingException, NoSuchAlgorithmException, IOException {
+	@RequestMapping(value = {"/is/query"}, method = {RequestMethod.POST, RequestMethod.GET})
+	public String query(@RequestParam(value = "msToken", required = true) String msToken, RedirectAttributes redirectAttrs, HttpServletRequest request) throws KeyStoreException, JsonParseException, JsonMappingException, NoSuchAlgorithmException, IOException {
 		String sessionMngrUrl = System.getenv("SESSION_MANAGER_URL");
 
 		List<NameValuePair> requestParams = new ArrayList<NameValuePair>();
@@ -87,12 +87,12 @@ public class AuthenticateController {
 			String sealSessionId = resp.getSessionData().getSessionId();
 			requestParams.clear();
 			requestParams.add(new NameValuePair("sessionId", sealSessionId));
-			LinkedHashMap<?, ?> idpRequest = (LinkedHashMap<?, ?>) resp.getSessionData().getSessionVariables().get("idpRequest");
+			LinkedHashMap<?, ?> idpRequest = (LinkedHashMap<?, ?>) resp.getSessionData().getSessionVariables().get("apRequest");
 			if (idpRequest == null) {
 				LOG.error("no idpRequest found in session" + sealSessionId);
 				return "redirect:/authfail";
 			} else {
-				return "redirect:/saml/login?session=" + sealSessionId + "?callback=/as/callback";
+				return "redirect:/saml/login?session=" + sealSessionId + "?callback=/is/callback";
 			}
 		} else {
 			LOG.error("Something wrong with the SM session: " + resp.getError());


### PR DESCRIPTION
## Proposed Changes
The PR includes minor changes including:

1.  **New endpoint:** Includes `is/query`  endpoint added via a new controller (`ISController`)
2. **New callback**: Includes a new callback controller `is/callback` managing the logic of the callback from an incoming is/query. This callback differs from the `as/callback` as it stores the assertion recovered Datastore into `dsResponse` and `dsMetadata` in the sessionManager, instead of `datastore`.
3. **Config minor changes**:  `SAMLWithRelayStateEntryPoint` now accepts a callback to be passed by value supporting multiple callback entries (this value was previously a constant)

To better separate concerns, the concerns regarding build, style and configuration were processed into a different PR (#5)

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [X] Build locally
- [X] Code format / lint
- [X] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
It  has only included UC 1.01 flow

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
The flow followed by called this endpoint follows the `UC 3.02` flow:
  * Sends an `AuthN` call to the IDP
  * Receives the callback at a separated callback (`is/callback`)
  * Stores the SAML assertion result into `dsResponse`


## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
None, the previous endpoints are still working as they were


